### PR TITLE
[WIRES] Make plugin compatible with wires refactor

### DIFF
--- a/pennylane_honeywell/device.py
+++ b/pennylane_honeywell/device.py
@@ -64,7 +64,9 @@ class HQSDevice(QubitDevice):
     r"""Honeywell Quantum Services device for PennyLane.
 
     Args:
-        wires (int): the number of wires to initialize the device with
+        wires (int or Iterable[Number, str]]): Number of wires to initialize the device with,
+            or iterable that contains unique labels for the subsystems as numbers (i.e., ``[-1, 0, 2]``)
+            or strings (``['ancilla', 'q1', 'q2']``).
         machine (str): name of the Honeywell machine to execute on
         shots (int): number of circuit evaluations/random samples used
             to estimate expectation values of observables

--- a/pennylane_honeywell/device.py
+++ b/pennylane_honeywell/device.py
@@ -78,7 +78,7 @@ class HQSDevice(QubitDevice):
     """
     # pylint: disable=too-many-instance-attributes
     name = "Honeywell Quantum Solutions PennyLane plugin"
-    pennylane_requires = ">=0.9.0"
+    pennylane_requires = ">=0.11.0"
     version = __version__
     author = "Xanadu Inc."
     _capabilities = {

--- a/pennylane_honeywell/device.py
+++ b/pennylane_honeywell/device.py
@@ -78,7 +78,7 @@ class HQSDevice(QubitDevice):
     """
     # pylint: disable=too-many-instance-attributes
     name = "Honeywell Quantum Solutions PennyLane plugin"
-    pennylane_requires = ">=0.11.0"
+    pennylane_requires = ">=0.9.0"
     version = __version__
     author = "Xanadu Inc."
     _capabilities = {


### PR DESCRIPTION
This device uses `to_openquasm` to create a circuit, and the only change for the PennyLane wires refactor is to update the docstring.