### PR TITLE
Remove Python 3.6 CI check and update qubit unitary test

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.7, 3.8]
     steps:
       - name: Cancel Previous Runs
         uses: styfle/cancel-workflow-action@0.4.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-pennylane>=0.15
+git+https://github.com/PennyLaneAI/pennylane.git@master
 requests

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -202,22 +202,19 @@ class TestHQSDeviceIntegration:
     def test_invalid_op_exception(self):
         """Tests whether an exception is raised if the circuit is
         passed an unsupported operation."""
-
         dev = HQSDevice(2, machine=DUMMY_MACHINE, api_key=SOME_API_KEY)
 
-        U = np.array(
-            [
-                [0.6569534 + 0.35252813j, 0.56815252 + 0.34833727j],
-                [-0.56815252 - 0.34833727j, 0.61216718 + 0.42557631j],
-            ]
-        )
+        class DummyOp(qml.operation.Operation):
+            num_params = 0
+            num_wires = 1
+            par_domain = None
 
         @qml.qnode(dev)
         def circuit():
-            qml.QubitUnitary(U, wires=0)
+            DummyOp(wires=[0])
             return qml.expval(qml.PauliZ(0))
 
-        with pytest.raises(qml.DeviceError, match="Gate QubitUnitary not supported"):
+        with pytest.raises(qml.DeviceError, match="Gate DummyOp not supported"):
             circuit()
 
     @pytest.mark.parametrize("num_wires", [1, 3])


### PR DESCRIPTION
1. Removes the Python 3.6 CI check (otherwise the check fails when run with PennyLane core as core has deprecated it already)
2. A change to one of the tests was required. The `qml.QubitUnitary` operation now provides a decomposition https://github.com/PennyLaneAI/pennylane/pull/1427. Previously, one of the test cases depended on the fact that the Honeywell device doesn't support the `qml.QubitUnitary operation` and this test case assumed that an error is raised when applying the `qml.QubitUnitary operation`. This is not the behaviour anymore as the decomposition of the `qml.QubitUnitary` operation is applied to the Honeywell device and circuit execution is attempted afterwards. An error with the API key is being raised. 

The solution for 2. is to use a `DummyOp` in the test case.