### PR TITLE
Require PennyLane v0.23

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-pennylane>=0.15
+pennylane>=0.23
 requests
 pyjwt
 toml

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ with open("pennylane_honeywell/_version.py") as f:
 # Requirements should be as minimal as possible.
 # Avoid pinning, and use minimum version numbers
 # only where required.
-requirements = ["pennylane>=0.15", "requests", "pyjwt", "toml"]
+requirements = ["pennylane>=0.23", "requests", "pyjwt", "toml"]
 
 info = {
     # 'name' is the name that will be used by pip for installation


### PR DESCRIPTION
Require PennyLane v0.23 because of the import path change in https://github.com/PennyLaneAI/pennylane-honeywell/pull/22.