### PR TITLE
Change `QubitDevice.statistics` signature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@
 
 ### Breaking changes
 
+* Changed the signature of the `QubitDevice.statistics` method from
+
+  ```python
+  def statistics(self, observables, shot_range=None, bin_size=None, circuit=None):
+  ```
+
+  to
+
+  ```python
+  def statistics(self, circuit: QuantumScript, shot_range=None, bin_size=None):
+  ```
+
+  [#3421](https://github.com/PennyLaneAI/pennylane/pull/3421)
+
 ### Improvements
 
 ### Documentation

--- a/pennylane_honeywell/device.py
+++ b/pennylane_honeywell/device.py
@@ -476,7 +476,7 @@ class HQSDevice(QubitDevice):
         self._samples = self.generate_samples()
 
         # compute the required statistics
-        results = self.statistics(tape.observables)
+        results = self.statistics(tape)
 
         # Ensures that a combination with sample does not put
         # expvals and vars in superfluous arrays


### PR DESCRIPTION
From:
```python
def statistics(self, observables, shot_range=None, bin_size=None, circuit=None):
```
To:
```python
def statistics(self, circuit: QuantumScript, shot_range=None, bin_size=None):
```

**Note:** `observables` can still be accessed inside the `statistics` method by using `circuit.observables`.