### PR TITLE
Remove usage of `MeasurementProcess.return_type`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 ### Improvements
 
+* With the introduction of custom measurement classes, all the `MeasurementProcess.return_type`
+  checks have been changed by `isinstance` checks.
+  [(#36)](https://github.com/PennyLaneAI/pennylane-honeywell/pull/36)
+
 ### Documentation
 
 ### Bug fixes
@@ -13,8 +17,10 @@
 ### Contributors
 
 This release contains contributions from (in alphabetical order):
+Albert Mitjans-Coma
 
 ---
+
 # Release 0.23.0
 
 ### Bug fixes
@@ -97,6 +103,7 @@ Maria Schuld
 Initial public release.
 
 ### Contributors
+
 This release contains contributions from:
 
 Nathan Killoran

--- a/pennylane_honeywell/device.py
+++ b/pennylane_honeywell/device.py
@@ -480,7 +480,7 @@ class HQSDevice(QubitDevice):
 
         # Ensures that a combination with sample does not put
         # expvals and vars in superfluous arrays
-        all_sampled = all(obs.return_type is Sample for obs in tape.observables)
+        all_sampled = all(isinstance(obs, Sample) for obs in tape.observables)
         if tape.is_sampled and not all_sampled:
             return self._asarray(results, dtype="object")  # pragma: no cover
 


### PR DESCRIPTION
❗ DO NOT MERGE before this PR: PennyLaneAI/pennylane#3425