### PR TITLE
Update plugin to work with the new PennyLane return types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,12 @@
-# Release 0.24.0-dev
+# Release 0.30.0-dev
 
 ### New features since last release
 
 ### Breaking changes
 
 ### Improvements
+
+* Updated the plugin to be compatible with the new PennyLane return type system.
 
 ### Documentation
 


### PR DESCRIPTION
* Updated `HQSDevice` to be consistent with `QubitDevice` for new return types.
  * Added `_execute_legacy` function which wraps `execute` so that the execution pipeline works for the old return types.
  * Updated `execute` to handle the new return type.