### PR TITLE
require 0.30 rc branch

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ with open("pennylane_honeywell/_version.py") as f:
 # Avoid pinning, and use minimum version numbers
 # only where required.
 requirements = [
-    "pennylane @ git+https://github.com/PennyLaneAI/pennylane.git",
+    "pennylane @ git+https://github.com/PennyLaneAI/pennylane.git@v0.30.0-rc0",
     "requests",
     "pyjwt",
     "toml",


### PR DESCRIPTION
as title says. this is to make plugin-test-matrix pass, and will need to be updated before releasing this plugin