### PR TITLE
Revert "require 0.30 rc branch (#42)"

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ with open("pennylane_honeywell/_version.py") as f:
 # Avoid pinning, and use minimum version numbers
 # only where required.
 requirements = [
-    "pennylane @ git+https://github.com/PennyLaneAI/pennylane.git@v0.30.0-rc0",
+    "pennylane @ git+https://github.com/PennyLaneAI/pennylane.git",
     "requests",
     "pyjwt",
     "toml",


### PR DESCRIPTION
This reverts commit a0826044ef73db9aaeda74e643c23105c341d482.

Now that plugin-test-matrix [is passing for RC](https://github.com/PennyLaneAI/plugin-test-matrix/actions/runs/4830960637), I'm happy. Unfortunately, pinning to RC makes the `latest` build fail! Idk if we should start doing plugin RC branches, but we should come up with a way to have latest _and_ RC passing near release-time if a plugin depends on changes in the upcoming PL release. To discuss later.