### PR TITLE
Switch to GA4

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -64,7 +64,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = 'PennyLane-Honeywell'
-copyright = "2022, Xanadu Quantum Technologies Inc."
+copyright = "2023, Xanadu Quantum Technologies Inc."
 author = 'Xanadu Inc.'
 
 add_module_names = False
@@ -137,7 +137,7 @@ html_theme_options = {
     ],
     "toc_overview": True,
     "navbar_active_link": 3,
-    "google_analytics_tracking_id": "UA-130507810-1"
+    "google_analytics_tracking_id": "G-C480Z9JL0D"
 }
 
 edit_on_github_project = 'PennyLaneAI/pennylane-honeywell'


### PR DESCRIPTION
Google is deprecating Universal Analytics on July 1st. This PR replaces that tag with the newer GA4 tag.