### PR TITLE
remove test cases now that disable_return is deprecated

### DIFF
--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -133,7 +133,6 @@ class MockResponseWithTokens:
 
 class MockResponseUnsuccessfulRequest:
     def __init__(self):
-
         self.status_code = "Not 200"
         self.mock_post_response = {
             "status_code": "Not 200",
@@ -322,7 +321,6 @@ class TestHQSDevice:
 
         class MockResponseForExpired:
             def __init__(self):
-
                 self.status_code = code
                 self.mock_post_response = {
                     "status_code": str(code),
@@ -882,13 +880,9 @@ class TestHQSDeviceIntegration:
             ([0, 1, 1], REF_RESULTS_011),
         ],
     )
-    @pytest.mark.parametrize("old_return", [True, False])
-    def test_reference_results_correct_expval(self, wire_flip_idx, ref_result, old_return, monkeypatch):
+    def test_reference_results_correct_expval(self, wire_flip_idx, ref_result, monkeypatch):
         """Tests that a simple circuit with a known specific result from the platform leads to the proper
         expectation value in PennyLane."""
-        if old_return:
-            qml.disable_return()
-
         num_wires = len(wire_flip_idx)
         dev = qml.device(
             "honeywell.hqs",
@@ -917,9 +911,6 @@ class TestHQSDeviceIntegration:
         res = circuit()
         expected = (-1) ** np.array(wire_flip_idx)
         assert np.all(expected == res)
-
-        if old_return:
-            qml.enable_return()
 
     def test_analytic_error(self):
         """Test that instantiating the device with `shots=None` results in an error"""


### PR DESCRIPTION
The old return system is being deprecated, so these test cases don't need to run anymore