### PR TITLE
avoid deprecated tape sampling properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Improvements 🛠
 
 * Avoid using the now-deprecated `tape.is_sampled` property.
-  [(#)]()
+  [(#55)](https://github.com/PennyLaneAI/pennylane-honeywell/pull/55)
 
 ### Breaking changes 💔
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ### Improvements 🛠
 
+* Avoid using the now-deprecated `tape.is_sampled` property.
+  [(#)]()
+
 ### Breaking changes 💔
 
 ### Deprecations 👋
@@ -15,6 +18,8 @@
 ### Contributors ✍️
 
 This release contains contributions from (in alphabetical order):
+
+Matthew Silverman
 
 ---
 # Release 0.33.0

--- a/pennylane_honeywell/device.py
+++ b/pennylane_honeywell/device.py
@@ -31,7 +31,7 @@ import pennylane as qml
 import requests
 import toml
 from pennylane import DeviceError, QubitDevice
-from pennylane.measurements import Sample
+from pennylane.measurements import SampleMP, CountsMP, ClassicalShadowMP, ShadowExpvalMP
 
 from ._version import __version__
 
@@ -479,8 +479,10 @@ class HQSDevice(QubitDevice):
 
         # Ensures that a combination with sample does not put
         # expvals and vars in superfluous arrays
-        all_sampled = all(obs.return_type is Sample for obs in tape.observables)
-        if tape.is_sampled and not all_sampled:
+        sample_types = (SampleMP, CountsMP, ClassicalShadowMP, ShadowExpvalMP)
+        is_sampled = any(isinstance(m, sample_types) for m in tape.measurements)
+        all_sampled = all(isinstance(m, sample_types) for m in tape.measurements)
+        if is_sampled and not all_sampled:
             return self._asarray(results, dtype="object")  # pragma: no cover
 
         return self._asarray(results)

--- a/pennylane_honeywell/device.py
+++ b/pennylane_honeywell/device.py
@@ -481,7 +481,7 @@ class HQSDevice(QubitDevice):
         # expvals and vars in superfluous arrays
         sample_types = (SampleMP, CountsMP, ClassicalShadowMP, ShadowExpvalMP)
         is_sampled = any(isinstance(m, sample_types) for m in tape.measurements)
-        all_sampled = all(isinstance(m, sample_types) for m in tape.measurements)
+        all_sampled = all(isinstance(m, SampleMP) for m in tape.measurements)
         if is_sampled and not all_sampled:
             return self._asarray(results, dtype="object")  # pragma: no cover
 


### PR DESCRIPTION
I'm using the plugin's previously-existing definition of "all_sampled", but perhaps it should be changed to be all `sample_types`. lmk if you'd prefer the other way, they should both pass tests.

found in PennyLaneAI/plugin-test-matrix#57