### PR TITLE
Update ubuntu version to 24.04 in .readthedocs.yml

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -10,7 +10,7 @@ python:
       path: .
 
 build:
-  os: ubuntu-22.04
+  os: ubuntu-24.04
   tools:
     python: "3.9"
   apt_packages:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Release 0.34.1
 
 ### Improvement changes
-* Bumped `.readthedocs.yml` up to Ubuntu-24.04
+* Bumped `.readthedocs.yml` up to Ubuntu-24.04 [(#74)](https://github.com/PennyLaneAI/pennylane-honeywell/pull/74)
 
 ### Breaking changes 💔
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Release 0.34.1
 
+### Improvement changes
+* Bumped `.readthedocs.yml` up to Ubuntu-24.04
+
 ### Breaking changes 💔
 
 * Pin the PennyLane version to <0.35
@@ -8,6 +11,7 @@
 
 This release contains contributions from (in alphabetical order):
 
+Runor Agbaire
 Matthew Silverman
 
 ---


### PR DESCRIPTION
**Description of the Change:**
Upgrading the readthedocs.yml runner to Ubuntu-24.04 from Ubuntu22.04; 22.04 is in end of life.

**Benefits:**
The readthedocs runner gets upgrade.

**Possible Drawbacks:**
There could be potential compatibility issues with sphinx and other packages. None were found in the PR run.

**Related GitHub Issues:**
